### PR TITLE
Fix undefined variable $current_user_is_vendor error

### DIFF
--- a/classes/class-mvx-coupon.php
+++ b/classes/class-mvx-coupon.php
@@ -53,8 +53,7 @@ class MVX_Coupon {
 
         if ($new_status != $old_status && $post->post_status == 'publish') {
             $current_user = get_current_vendor_id();
-            if ($current_user)
-                $current_user_is_vendor = is_user_mvx_vendor($current_user);
+            $current_user_is_vendor = is_user_mvx_vendor($current_user);
             if ($current_user_is_vendor) {
                 //send mails to customer for new vendor coupon
                 $vendor = get_mvx_vendor_by_term(get_user_meta($current_user, '_vendor_term_id', true));

--- a/classes/class-mvx-product.php
+++ b/classes/class-mvx-product.php
@@ -702,8 +702,7 @@ class MVX_Product {
 
         if ($new_status != $old_status && $post->post_status == 'pending') {
             $current_user = get_current_vendor_id();
-            if ($current_user)
-                $current_user_is_vendor = is_user_mvx_vendor($current_user);
+            $current_user_is_vendor = is_user_mvx_vendor($current_user);
             if ($current_user_is_vendor) {
                 //send mails to admin for new vendor product
                 $vendor = get_mvx_vendor_by_term(get_user_meta($current_user, '_vendor_term_id', true));
@@ -712,8 +711,7 @@ class MVX_Product {
             }
         } else if ($new_status != $old_status && $post->post_status == 'publish') {
             $current_user = get_current_vendor_id();
-            if ($current_user)
-                $current_user_is_vendor = is_user_mvx_vendor($current_user);
+            $current_user_is_vendor = is_user_mvx_vendor($current_user);
             if ($current_user_is_vendor) {
                 //send mails to admin for new vendor product
                 $vendor = get_mvx_vendor_by_term(get_user_meta($current_user, '_vendor_term_id', true));
@@ -759,8 +757,7 @@ class MVX_Product {
         $vendor = get_mvx_product_vendors($post->ID);
         $commission_per_poduct = get_post_meta($post->ID, '_commission_per_product', true);
         $current_user = get_current_vendor_id();
-        if ($current_user)
-            $current_user_is_vendor = is_user_mvx_vendor($current_user);
+        $current_user_is_vendor = is_user_mvx_vendor($current_user);
         $html .= '<div class="options_group" > <table class="form-field form-table">';
         $html .= '<tbody>';
         if ($vendor) {

--- a/classes/class-mvx-vendor-dashboard.php
+++ b/classes/class-mvx-vendor-dashboard.php
@@ -2475,8 +2475,7 @@ Class MVX_Admin_Dashboard {
             $status_for_send_mail_to_admin = apply_filters('mvx_send_coupon_mail_admin_status', array('draft'));
             if ( !in_array( $status, $status_for_send_mail_to_admin) ) {
                 $current_user = get_current_vendor_id();
-                if ($current_user)
-                    $current_user_is_vendor = is_user_mvx_vendor($current_user);
+                $current_user_is_vendor = is_user_mvx_vendor($current_user);
                 if ($current_user_is_vendor && !get_post_meta($post_id, 'mvx_coupon_mail_send_to_admin')) {
                     //send mails to admin for new vendor coupon
                     $vendor = get_mvx_vendor_by_term(get_user_meta($current_user, '_vendor_term_id', true));


### PR DESCRIPTION
When `$current_user` is `false`, we would get a PHP error since `$current_user_is_vendor` would not be defined.