### PR TITLE
Fix deprecation warning on Transaction Details submenu

### DIFF
--- a/admin/class-mvx-settings.php
+++ b/admin/class-mvx-settings.php
@@ -50,7 +50,7 @@ class MVX_Settings {
 
             $submenu[ $slug ][] = [ __( '<div id="help-and-support">Help & Support</div>', 'multivendorx' ), 'manage_woocommerce', 'https://multivendorx.com/' ];
 
-            add_submenu_page( null, __( 'Transaction Details', 'multivendorx' ), __( 'Transaction Details', 'multivendorx' ), 'manage_woocommerce', 'mvx-transaction-details', array( $this, 'mvx_transaction_details' ) );
+            add_submenu_page( '', __( 'Transaction Details', 'multivendorx' ), __( 'Transaction Details', 'multivendorx' ), 'manage_woocommerce', 'mvx-transaction-details', array( $this, 'mvx_transaction_details' ) );
         }
     }
 


### PR DESCRIPTION
Resolves the following deprecation warnings on PHP 8.3

```
PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in wp-includes/functions.php on line 7329
PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in wp-includes/functions.php on line 2189
```

Unclear if this breaks anything.