### PR TITLE
Optimize vendor order saving process

### DIFF
--- a/classes/class-mvx-order.php
+++ b/classes/class-mvx-order.php
@@ -613,11 +613,9 @@ class MVX_Order {
                     }
                     break;
             }
-        
-            // Save the vendor order after each meta update
-            $vendor_order->save();
         }
-        
+
+        $vendor_order->save();
 
         $vendor_order->update_meta_data('_mvx_order_version', $MVX->version);
         $vendor_order->update_meta_data('_vendor_id', absint($args['vendor_id']));

--- a/classes/class-mvx-order.php
+++ b/classes/class-mvx-order.php
@@ -1513,8 +1513,7 @@ class MVX_Order {
         $refund_reason_options = get_mvx_global_settings('refund_order_msg') ? explode( "||", get_mvx_global_settings('refund_order_msg') ) : array();
         $refund_button_text = apply_filters( 'mvx_customer_my_account_refund_request_button_text', __( 'Request a refund', 'multivendorx' ), $order );
         // Print refund messages, if any
-        if( mvx_get_customer_refund_order_msg( $order, $refund_settings ) ) {
-            $msg_data = mvx_get_customer_refund_order_msg( $order, $refund_settings );
+        if( $msg_data = mvx_get_customer_refund_order_msg( $order, $refund_settings ) ) {
             $type = isset( $msg_data['type'] ) ? $msg_data['type'] : 'info';
             ?>
             <div class="woocommerce-Message woocommerce-Message--<?php echo $type; ?> woocommerce-<?php echo $type; ?>">

--- a/classes/class-mvx-post-commission.php
+++ b/classes/class-mvx-post-commission.php
@@ -145,7 +145,6 @@ class MVX_Commission {
             } else {
                 $commission_rates = $order->get_meta( 'order_items_commission_rates', true);
                 foreach ($order->get_items() as $item_id => $item) {
-                    $product = $item->get_product();
                     $meta_data = $item->get_meta_data();
                     // get item commission
                     foreach ( $meta_data as $meta ) {


### PR DESCRIPTION
Move `$vendor_order->save()` outside of the loop, to prevent unnecessary database strain.
Seemingly there is no reason to be saving within the loop