### PR TITLE
Make vendor term generation more robust

### DIFF
--- a/classes/class-mvx-vendor-details.php
+++ b/classes/class-mvx-vendor-details.php
@@ -204,7 +204,7 @@ class MVX_Vendor {
      */
     public function generate_term() {
         global $MVX;
-        if (!$this->term_id) {
+        if (!$this->term_id || !term_exists($this->user_data->user_login, $MVX->taxonomy->taxonomy_name)) {
             $term = wp_insert_term($this->user_data->user_login, $MVX->taxonomy->taxonomy_name);
             if (!is_wp_error($term)) {
                 update_user_meta($this->id, '_vendor_term_id', $term['term_id']);
@@ -244,9 +244,7 @@ class MVX_Vendor {
     public function update_page_title($title = '') {
         global $MVX;
         $this->term_id = get_user_meta($this->id, '_vendor_term_id', true);
-        if (!$this->term_id) {
-            $this->generate_term();
-        }
+        $this->generate_term();
         if (!empty($title) && isset($this->term_id)) {
             if (!is_wp_error(wp_update_term($this->term_id, $MVX->taxonomy->taxonomy_name, array('name' => $title)))) {
                 return true;
@@ -264,9 +262,7 @@ class MVX_Vendor {
     public function update_page_slug($slug = '') {
         global $MVX;
         $this->term_id = get_user_meta($this->id, '_vendor_term_id', true);
-        if (!$this->term_id) {
-            $this->generate_term();
-        }
+        $this->generate_term();
         if (!empty($slug) && isset($this->term_id)) {
             if (!is_wp_error(wp_update_term($this->term_id, $MVX->taxonomy->taxonomy_name, array('slug' => $slug)))) {
                 return true;

--- a/classes/class-mvx-vendor-details.php
+++ b/classes/class-mvx-vendor-details.php
@@ -204,6 +204,7 @@ class MVX_Vendor {
      */
     public function generate_term() {
         global $MVX;
+        $this->term_id = get_user_meta($this->id, '_vendor_term_id', true);
         if (!$this->term_id || !term_exists($this->user_data->user_login, $MVX->taxonomy->taxonomy_name)) {
             $term = wp_insert_term($this->user_data->user_login, $MVX->taxonomy->taxonomy_name);
             if (!is_wp_error($term)) {
@@ -243,7 +244,6 @@ class MVX_Vendor {
      */
     public function update_page_title($title = '') {
         global $MVX;
-        $this->term_id = get_user_meta($this->id, '_vendor_term_id', true);
         $this->generate_term();
         if (!empty($title) && isset($this->term_id)) {
             if (!is_wp_error(wp_update_term($this->term_id, $MVX->taxonomy->taxonomy_name, array('name' => $title)))) {
@@ -261,7 +261,6 @@ class MVX_Vendor {
      */
     public function update_page_slug($slug = '') {
         global $MVX;
-        $this->term_id = get_user_meta($this->id, '_vendor_term_id', true);
         $this->generate_term();
         if (!empty($slug) && isset($this->term_id)) {
             if (!is_wp_error(wp_update_term($this->term_id, $MVX->taxonomy->taxonomy_name, array('slug' => $slug)))) {


### PR DESCRIPTION
We're not entirely sure how it happens, but in multiple instances the term of the vendor is being deleted, but the `_vendor_term_id` user meta remains, which causes critical errors on several places.

Because of that, made the generation of the vendor term more robust by also checking if the term actually exists.
