### PR TITLE
Fix filter being used in Vendor Followed email heading

### DIFF
--- a/classes/emails/class-mvx-email-vendor-followed.php
+++ b/classes/emails/class-mvx-email-vendor-followed.php
@@ -50,7 +50,7 @@ class WC_Email_Vendor_Followed extends WC_Email {
      * @return string
      */
     public function get_default_heading() {
-        return apply_filters('mvx_vendor_new_order_email_heading', __('Vendor Followed', 'multivendorx'), $this->object);
+        return apply_filters('mvx_vendor_followed_email_heading', __('Vendor Followed', 'multivendorx'), $this->object);
     }
 
     /**


### PR DESCRIPTION
The "New Product from Followed Vendor" email was using the default heading for the "New Order"

https://github.com/multivendorx/MultiVendorX/blob/083ed2a5143fad14d68dc793b88d06f27d75058a/classes/emails/class-mvx-email-vendor-new-order.php#L60