### PR TITLE
Fix unclosed table tag on Vendor Followers page

### DIFF
--- a/templates/vendor-dashboard/vendor_followers.php
+++ b/templates/vendor-dashboard/vendor_followers.php
@@ -29,6 +29,9 @@ if ( !empty($mvx_vendor_followed_by_customer) ) {
             echo '<td>' . $row ['customer_name'] = $user_details->user_email . '</td></tr>';
         }
     }
+    ?>
+    </table>
+<?php
 }else {
     echo esc_html_e('No customer follows you till now.', 'multivendorx');          
 }


### PR DESCRIPTION
The page still works without the closing tag since browsers automatically try to fix the HTML syntax. However, this causes issues with the Query Monitor plugin